### PR TITLE
Convert JS code to TypeScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ yarn-error.log
 # build output
 
 index.js
+index.d.ts
   
 
 # Xcode

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 node_modules/
 npm-debug.log
 yarn-error.log
+
+# build output
+
+index.js
   
 
 # Xcode
@@ -29,4 +33,3 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-      

--- a/index.js
+++ b/index.js
@@ -1,6 +1,0 @@
-import { NativeModules, requireNativeComponent } from 'react-native';
-
-const { RNCAppleAuthentication } = NativeModules;
-export { RNCAppleAuthentication as SignInWithApple };
-
-export const SignInWithAppleButton = requireNativeComponent('RNCSignInWithAppleButton');

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,108 @@
+import { NativeModules, requireNativeComponent } from 'react-native';
+
+export interface SignInWithAppleOptions {
+  /**
+   * The scopes that you are requesting. Supply an array. Defaults to an empty array (no scopes).
+   */
+  requestedScopes?: SignInWithAppleScope[];
+
+  /**
+   * The operation that you would like to perform.
+   */
+  requestedOperation?: SignInWithAppleOperation;
+
+  /**
+   * Typically you leave this property set to nil the first time you authenticate a user.
+   * Otherwise, if you previously received an SignInWithAppleCredential set this property to the value from the user property.
+   * Must be set for Refresh and Logout operations.
+   */
+  user?: string;
+
+  /**
+   * Data that’s returned to you unmodified in the corresponding credential after a successful authentication.
+   * Used to verify that the response was from the request you made. Can be used to avoid replay attacks.
+   */
+  state?: string;
+};
+
+export interface SignInWithAppleCredential {
+  /**
+   * A JSON Web Token (JWT) that securely communicates information about the user to your app.
+   */
+  identityToken: string;
+
+  /**
+   * A short-lived token used by your app for proof of authorization when interacting with the app’s server counterpart.
+   */
+  authorizationCode: string;
+
+  /**
+   * An arbitrary string that your app provided to the request that generated the credential.
+   * You can set this in SignInWithAppleOptions.
+   */
+  user: string;
+
+  /**
+   * An identifier associated with the authenticated user.
+   * You can use this to check if the user is still authenticated later.
+   * This is stable and can be shared across apps released under the same development team.
+   * The same user will have a different identifier for apps released by other developers.
+   */
+  state?: string;
+
+  /**
+   * The contact information the user authorized your app to access.
+   */
+  authorizedScopes: SignInWithAppleScope[];
+
+  /**
+   * The user’s name. Might not present if you didn't request access or if the user denied access.
+   */
+  fullName?: string;
+
+  /**
+   * The user’s email address. Might not present if you didn't request access or if the user denied access.
+   */
+  email?: string;
+
+  /**
+   * A value that indicates whether the user appears to be a real person.
+   */
+  realUserStatus: SignInWithAppleUserDetectionStatus;
+};
+
+export interface SignInWithAppleScopes {
+  FULL_NAME: string;
+  EMAIL: string;
+};
+
+export type SignInWithAppleScope = keyof SignInWithAppleScopes;
+
+export interface SignInWithAppleOperations {
+  LOGIN: string;
+  LOGOUT: string;
+  REFRESH: string;
+  IMPLICIT: string;
+};
+
+export interface SignInWithAppleUserDetectionStatuses {
+  LIKELY_REAL: string;
+  UNKNOWN: string;
+  UNSUPPORTED: string;
+};
+
+export type SignInWithAppleUserDetectionStatus = keyof SignInWithAppleUserDetectionStatuses;
+
+export type SignInWithAppleOperation = keyof SignInWithAppleOperations;
+
+export interface ISignInWithApple {
+  requestAsync: (signInWithAppleOptions: SignInWithAppleOptions) => Promise<SignInWithAppleCredential>;
+  Scope: SignInWithAppleScopes;
+  Operation: SignInWithAppleOperations;
+  UserDetectionStatus: SignInWithAppleUserDetectionStatuses;
+};
+
+const { RNCAppleAuthentication } = NativeModules;
+export { RNCAppleAuthentication as SignInWithApple };
+
+export const SignInWithAppleButton = requireNativeComponent('RNCSignInWithAppleButton');

--- a/index.ts
+++ b/index.ts
@@ -103,7 +103,6 @@ export interface ISignInWithApple {
   UserDetectionStatus: SignInWithAppleUserDetectionStatuses;
 }
 
-const { RNCAppleAuthentication } = NativeModules;
-export { RNCAppleAuthentication as SignInWithApple };
+export const SignInWithApple: ISignInWithApple = NativeModules.RNCAppleAuthentication;
 
 export const SignInWithAppleButton = requireNativeComponent('RNCSignInWithAppleButton');

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import { NativeModules, requireNativeComponent } from 'react-native';
+import { ComponentType } from 'react';
 
 export interface SignInWithAppleOptions {
   /**
@@ -105,4 +106,47 @@ export interface ISignInWithApple {
 
 export const SignInWithApple: ISignInWithApple = NativeModules.RNCAppleAuthentication;
 
-export const SignInWithAppleButton = requireNativeComponent('RNCSignInWithAppleButton');
+export interface SignInWithAppleButtonProps {
+  /**
+   * The callback which is called when the user pressed the button.
+   */
+  onPress: () => void;
+
+  /**
+   * Controls the text that is shown on the button.
+   */
+  type?: SignInWithAppleButtonType;
+
+  /**
+   * Controls the style of the button.
+   */
+  style?: SignInWithAppleButtonStyle;
+
+  /**
+   * The radius of the corners of the button.
+   */
+  cornerRadius?: number;
+}
+
+export interface SignInWithAppleButtonTypes {
+  DEFAULT: string;
+  SIGN_UP: string;
+  CONTINUE: string;
+}
+
+export type SignInWithAppleButtonType = keyof SignInWithAppleButtonTypes;
+
+export interface SignInWithAppleButtonStyles {
+  BLACK: string;
+  WHITE: string;
+  WHITE_OUTLINE: string;
+}
+
+export type SignInWithAppleButtonStyle = keyof SignInWithAppleButtonStyles;
+
+export type ISignInWithAppleButton = ComponentType<SignInWithAppleButtonProps> & {
+  Type: SignInWithAppleButtonTypes;
+  Style: SignInWithAppleButtonStyles;
+}
+
+export const SignInWithAppleButton: ISignInWithAppleButton = requireNativeComponent('RNCSignInWithAppleButton');

--- a/index.ts
+++ b/index.ts
@@ -73,24 +73,57 @@ export interface SignInWithAppleCredential {
 }
 
 export interface SignInWithAppleScopes {
+  /**
+   * A scope that includes the user’s full name.
+   */
   FULL_NAME: string;
+  
+  /**
+   * A scope that includes the user’s email address.
+   */
   EMAIL: string;
 }
 
 export type SignInWithAppleScope = keyof SignInWithAppleScopes;
 
 export interface SignInWithAppleOperations {
+  /**
+   * An operation used to authenticate a user.
+   */
   LOGIN: string;
+
+  /**
+   * An operation that ends an authenticated session.
+   */
   LOGOUT: string;
+
+  /**
+   * An operation that refreshes the logged-in user’s credentials.
+   */
   REFRESH: string;
+
+  /**
+   * An operation that depends on the particular kind of credential provider.
+   */
   IMPLICIT: string;
 }
 
 export type SignInWithAppleOperation = keyof SignInWithAppleOperations;
 
 export interface SignInWithAppleUserDetectionStatuses {
+  /**
+   * The user appears to be a real person.
+   */
   LIKELY_REAL: string;
+
+  /**
+   * The system hasn’t determined whether the user might be a real person.
+   */
   UNKNOWN: string;
+
+  /**
+   * The system can’t determine this user’s status as a real person.
+   */
   UNSUPPORTED: string;
 }
 
@@ -98,9 +131,25 @@ export type SignInWithAppleUserDetectionStatus = keyof SignInWithAppleUserDetect
 
 
 export interface ISignInWithApple {
+  /**
+   * Perform a Sign In with Apple request with the given SignInWithAppleOptions.
+   * The method will return a Promise which will resolve to a SignInWithAppleCredential on success.
+   * You should make sure you include error handling.
+   */
   requestAsync: (signInWithAppleOptions: SignInWithAppleOptions) => Promise<SignInWithAppleCredential>;
+  /**
+   * Controls which scopes you are requesting when the call SignInWithApple.requestAsync().
+   */
   Scope: SignInWithAppleScopes;
+  /**
+   * Controls what operation you are requesting when the call SignInWithApple.requestAsync().
+   */
   Operation: SignInWithAppleOperations;
+  /**
+   * A value that indicates whether the user appears to be a real person.
+   * You get this in the realUserStatus property of a SignInWithAppleCredential object.
+   * It can be used as one metric to help prevent fraud.
+   */
   UserDetectionStatus: SignInWithAppleUserDetectionStatuses;
 }
 

--- a/index.ts
+++ b/index.ts
@@ -85,6 +85,8 @@ export interface SignInWithAppleOperations {
   IMPLICIT: string;
 };
 
+export type SignInWithAppleOperation = keyof SignInWithAppleOperations;
+
 export interface SignInWithAppleUserDetectionStatuses {
   LIKELY_REAL: string;
   UNKNOWN: string;
@@ -93,7 +95,6 @@ export interface SignInWithAppleUserDetectionStatuses {
 
 export type SignInWithAppleUserDetectionStatus = keyof SignInWithAppleUserDetectionStatuses;
 
-export type SignInWithAppleOperation = keyof SignInWithAppleOperations;
 
 export interface ISignInWithApple {
   requestAsync: (signInWithAppleOptions: SignInWithAppleOptions) => Promise<SignInWithAppleCredential>;

--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ export interface SignInWithAppleOptions {
    * Used to verify that the response was from the request you made. Can be used to avoid replay attacks.
    */
   state?: string;
-};
+}
 
 export interface SignInWithAppleCredential {
   /**
@@ -69,12 +69,12 @@ export interface SignInWithAppleCredential {
    * A value that indicates whether the user appears to be a real person.
    */
   realUserStatus: SignInWithAppleUserDetectionStatus;
-};
+}
 
 export interface SignInWithAppleScopes {
   FULL_NAME: string;
   EMAIL: string;
-};
+}
 
 export type SignInWithAppleScope = keyof SignInWithAppleScopes;
 
@@ -83,7 +83,7 @@ export interface SignInWithAppleOperations {
   LOGOUT: string;
   REFRESH: string;
   IMPLICIT: string;
-};
+}
 
 export type SignInWithAppleOperation = keyof SignInWithAppleOperations;
 
@@ -91,7 +91,7 @@ export interface SignInWithAppleUserDetectionStatuses {
   LIKELY_REAL: string;
   UNKNOWN: string;
   UNSUPPORTED: string;
-};
+}
 
 export type SignInWithAppleUserDetectionStatus = keyof SignInWithAppleUserDetectionStatuses;
 
@@ -101,7 +101,7 @@ export interface ISignInWithApple {
   Scope: SignInWithAppleScopes;
   Operation: SignInWithAppleOperations;
   UserDetectionStatus: SignInWithAppleUserDetectionStatuses;
-};
+}
 
 const { RNCAppleAuthentication } = NativeModules;
 export { RNCAppleAuthentication as SignInWithApple };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
       "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
       "dev": true
+    },
+    "typescript": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "@react-native-community/apple-authentication",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/prop-types": {
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.2.tgz",
+      "integrity": "sha512-jYP2LWwlh+FTqGd9v7ynUKZzjj98T8x7Yclz479QdRhHfuW9yQ+0jjnD31eXSXutmBpppj5PYNLYLRfnZJvcfg==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.60.11",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.60.11.tgz",
+      "integrity": "sha512-JAe7/UCGhnXxTwHCix1Gs6EbbCTeqU8TxxKHKNrsVtECZ9cPYp1UmJoDIDaNTz8o1/9nTFOtPj7CvHp2hWpEIQ==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/react": "*"
+      }
+    },
+    "csstype": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react-native": "^0.59.9"
+  },
+  "devDependencies": {
+    "@types/react-native": "^0.60.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "tsc"
   },
   "keywords": [
     "react-native"
@@ -15,6 +16,7 @@
     "react-native": "^0.59.9"
   },
   "devDependencies": {
-    "@types/react-native": "^0.60.11"
+    "@types/react-native": "^0.60.11",
+    "typescript": "^3.6.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "files": [
+    "./index.ts"
+  ],
+  "compilerOptions": {
+    "target": "es6",
+    "module": "es2015",
+    "lib": ["es2015"],
+    "moduleResolution": "node"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "target": "es6",
     "module": "es2015",
     "lib": ["es2015"],
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "strict": true,
+    "declaration": true
   }
 }


### PR DESCRIPTION
# Summary

Convert the `index.js` file to TypeScript, and provide types and interfaces for all options, enums and returned objects.

This is part of the plan described in #2.

## TODO

- [x] Add types to `SignInWithApple` (with all enums and sub-types)
- [x] Add types to `SignInWithAppleButton`
- [x] Create a build script to export `index.ts` to `index.js` and `index.d.ts` (`tsc` with ES6 exports should be enough for now as the current JS code only exports as ES6 and no bundling is necessary)
- [ ] Make sure everything is well exported when transpiled.

## Test Plan

### What's required for testing (prerequisites)?

* A React-Native project already setup with TypeScript

### What are the steps to reproduce (after prerequisites)?

* Import this package and link it
* Use all features and make sure no type errors are popping up
* Make sure the module works as expected

## Compatibility

(Not applicable)

## Checklist

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
